### PR TITLE
Fix invalid free_episodes count

### DIFF
--- a/resources/lib/rtlinteractive/provider.py
+++ b/resources/lib/rtlinteractive/provider.py
@@ -185,9 +185,11 @@ class Provider(kodion.AbstractProvider):
             now_format = format_list[key]
             title = now_format['formatlong']
             format_id = now_format['formatid']
-            free_episodes = int(now_format.get('free_episodes', '0'))
+            catchuptext = now_format['catchuptext']
+            free_episodes = int(now_format.get('free_episodes', '0'))            
+            might_have_free_episodes = free_episodes >= 1 or catchuptext.find('FREE') != -1
 
-            if free_episodes >= 1:
+            if might_have_free_episodes:
                 format_item = DirectoryItem(title,
                                             context.create_uri(['format', format_id]))
 


### PR DESCRIPTION
Fix for invalid API response value in free_episodes by RTL:
http://www.kodinerds.net/index.php/Thread/39583-Bromix-repository/?postID=224879#post224879

Test Shows: "Exclusiv"
Related: https://github.com/bromix/plugin.video.vox-now.de/pull/2